### PR TITLE
Remove scope param

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ import { SpotifyApi } from '@spotify/web-api-ts-sdk';
 
 // Choose one of the following:
 const sdk = SpotifyApi.withUserAuthorization("client-id", "https://localhost:3000", ["scope1", "scope2"]);
-const sdk = SpotifyApi.withClientCredentials("client-id", "secret", ["scope1", "scope2"]);
+const sdk = SpotifyApi.withClientCredentials("client-id", "secret");
 ```
 
 Each of these factory methods will return a `SpotifyApi` instance, which you can use to make requests to the Spotify Web API.

--- a/src/SpotifyApi.ts
+++ b/src/SpotifyApi.ts
@@ -169,8 +169,8 @@ export class SpotifyApi {
         return new SpotifyApi(strategy, config);
     }
 
-    public static withClientCredentials(clientId: string, clientSecret: string, scopes: string[] = [], config?: SdkOptions): SpotifyApi {
-        const strategy = new ClientCredentialsStrategy(clientId, clientSecret, scopes);
+    public static withClientCredentials(clientId: string, clientSecret: string, config?: SdkOptions): SpotifyApi {//change
+        const strategy = new ClientCredentialsStrategy(clientId, clientSecret);
         return new SpotifyApi(strategy, config);
     }
 

--- a/src/auth/ClientCredentialsStrategy.ts
+++ b/src/auth/ClientCredentialsStrategy.ts
@@ -10,8 +10,7 @@ export default class ClientCredentialsStrategy implements IAuthStrategy {
 
     constructor(
         private clientId: string,
-        private clientSecret: string,
-        private scopes: string[] = []
+        private clientSecret: string
     ) {
     }
 
@@ -46,8 +45,7 @@ export default class ClientCredentialsStrategy implements IAuthStrategy {
 
     private async getTokenFromApi(): Promise<AccessToken> {
         const options = {
-            grant_type: 'client_credentials',
-            scope: this.scopes.join(' ')
+            grant_type: 'client_credentials'
         } as any;
 
         const bodyAsString = Object.keys(options).map(key => key + '=' + options[key]).join('&');


### PR DESCRIPTION
auth-module: Refactor ClientCredentialsStrategy constructor and request handling

Problem
The ClientCredentialsStrategy constructor included a 'scope' parameter, which was unnecessary and caused inconsistencies. Additionally, the main request in the same class included unnecessary scopes in the request body.

Solution
Refactored the ClientCredentialsStrategy constructor by removing the 'scope' parameter. Modified the main request handling in the same class to exclude unnecessary scopes from the request body. Updated the 'withClientCredentials' static method to align with the changes in the strategy.

Result
The ClientCredentialsStrategy now has a cleaner constructor without the 'scope' parameter, and the main request handling avoids including unnecessary scopes. The 'withClientCredentials' method is consistent with the updated strategy. The README has also been modified to reflect these changes.
